### PR TITLE
Added "enableRemoteModule: true in web".

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,8 @@ const createWindow = () => {
     width: 800,
     height: 600,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      enableRemoteModule: true,
     }
   });
 


### PR DESCRIPTION
Otherwise 'videoOptionsMenu.popup()' will not work in electron 10.0.