### PR TITLE
fixes #35 -issue with recording multiple videos in a single session

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -6,7 +6,7 @@ const { dialog, Menu } = remote;
 
 // Global state
 let mediaRecorder; // MediaRecorder instance to capture footage
-const recordedChunks = [];
+let recordedChunks = [];
 
 // Buttons
 const videoElement = document.querySelector('video');
@@ -105,4 +105,5 @@ async function handleStop(e) {
     writeFile(filePath, buffer, () => console.log('video saved successfully!'));
   }
 
+  recordedChunks = [];
 }


### PR DESCRIPTION
If you do not clear the recordedChunks array then subsequent video records are added to the same chunks array and faulty video files are recorded that contain duplicate data from previous recordings and corrupted end sequence data.